### PR TITLE
[FIX] Make treasure bags stack to 999

### DIFF
--- a/Items/Celestial/CelestialBag.cs
+++ b/Items/Celestial/CelestialBag.cs
@@ -18,7 +18,7 @@ namespace SOTS.Items.Celestial
 			item.value = 0;
 			item.rare = 6;
 			item.expert = true;
-			item.maxStack = 99;
+			item.maxStack = 999;
 			item.consumable = true;
 		}
 		public override int BossBagNPC => mod.NPCType("CelestialSerpentHead");

--- a/Items/Celestial/SubspaceBag.cs
+++ b/Items/Celestial/SubspaceBag.cs
@@ -17,7 +17,7 @@ namespace SOTS.Items.Celestial
 			item.height = 32;
 			item.value = 0;
 			item.rare = ItemRarityID.Red;
-			item.maxStack = 99;
+			item.maxStack = 999;
 			item.consumable = true;
 			item.expert = true;
 		}

--- a/Items/GelGear/PinkyBag.cs
+++ b/Items/GelGear/PinkyBag.cs
@@ -19,7 +19,7 @@ namespace SOTS.Items.GelGear
 			item.value = 0;
 			item.rare = ItemRarityID.LightPurple;
 			item.expert = true;
-			item.maxStack = 99;
+			item.maxStack = 999;
 			item.consumable = true;
 		}
 		public override int BossBagNPC => ModContent.NPCType<PutridPinkyPhase2>();

--- a/Items/IceStuff/PolarisBossBag.cs
+++ b/Items/IceStuff/PolarisBossBag.cs
@@ -19,7 +19,7 @@ namespace SOTS.Items.IceStuff
 			item.value = 0;
 			item.rare = ItemRarityID.Cyan;
 			item.expert = true;
-			item.maxStack = 99;
+			item.maxStack = 999;
 			item.consumable = true;
 		}
 		public override int BossBagNPC => ModContent.NPCType<Polaris>();

--- a/Items/Otherworld/TheAdvisorBossBag.cs
+++ b/Items/Otherworld/TheAdvisorBossBag.cs
@@ -19,7 +19,7 @@ namespace SOTS.Items.Otherworld
 			item.value = 0;
 			item.rare = 6;
 			item.expert = true;
-			item.maxStack = 99;
+			item.maxStack = 999;
 			item.consumable = true;
 		}
         public override void PostDrawInInventory(SpriteBatch spriteBatch, Vector2 position, Rectangle frame, Color drawColor, Color itemColor, Vector2 origin, float scale)

--- a/Items/Pyramid/CurseBag.cs
+++ b/Items/Pyramid/CurseBag.cs
@@ -19,7 +19,7 @@ namespace SOTS.Items.Pyramid
 			item.value = 0;
 			item.rare = ItemRarityID.LightPurple;
 			item.expert = true;
-			item.maxStack = 99;
+			item.maxStack = 999;
 			item.consumable = true;
 		}
 		public override int BossBagNPC => mod.NPCType("PharaohsCurse");


### PR DESCRIPTION
Fixes issue from https://discord.com/channels/696489851318435871/696492731819622444/911365756015489095 and allows treasure bags to stack to 999 instead of 99