### PR TITLE
Fix worldgen hanging when generating the gem structures in Remix worlds

### DIFF
--- a/WorldgenHelpers/GemStructuresWorldgenHelper.cs
+++ b/WorldgenHelpers/GemStructuresWorldgenHelper.cs
@@ -154,6 +154,7 @@ namespace SOTS.WorldgenHelpers
 		}
 		private static void PlaceAndGenerateAmber()
 		{
+			var isSandLike = (Tile t) => t.HasTile && (t.TileType == TileID.Sand || t.TileType == TileID.Ebonsand || t.TileType == TileID.Crimsand || t.TileType == TileID.Pearlsand);
 			int dungeonSide = -1; //-1 = dungeon on left, 1 = dungeon on right
 			if (Main.dungeonX > (int)(Main.maxTilesX / 2))
 			{
@@ -189,7 +190,7 @@ namespace SOTS.WorldgenHelpers
 				for (int j = 0; j < 1600; j++)
 				{
 					Tile tile = Framing.GetTileSafely(i, j);
-					if(tempWater > 7 && tile.HasTile && tile.TileType == TileID.Sand && Framing.GetTileSafely(i - 1, j).TileType == TileID.Sand && Framing.GetTileSafely(i + 1, j).TileType == TileID.Sand)
+					if(tempWater > 7 && isSandLike(tile) && isSandLike(Framing.GetTileSafely(i - 1, j)) && isSandLike(Framing.GetTileSafely(i + 1, j)))
                     {
 						if (tempY == -1)
 							tempY = j;


### PR DESCRIPTION
The only time sand blocks in the ocean will be infected at world generation time is in Remix-type seeds, so this change should not disrupt anything else in world generation. I have confirmed that the fix does solve the problem, and that the problem was in fact a bug in SOTS (by disabling all other mods and verifying that the hang occurred). I also have the check work with the Hallowed sand variant because 1.4.5 adds a secret seed that converts all blocks to their Hallowed equivalents, so this pre-empts any potential recurrence of the bug in such seeds once the mod is updated.